### PR TITLE
Create shell for event page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,7 @@
         "@types/react": "^18",
         "@types/react-dom": "^18",
         "eslint": "^8",
-        "eslint-config-next": "14.2.5",
+        "eslint-config-next": "^14.2.5",
         "eslint-plugin-jest-dom": "^5.4.0",
         "eslint-plugin-testing-library": "^6.3.0",
         "jest": "^29.7.0",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "@types/react": "^18",
     "@types/react-dom": "^18",
     "eslint": "^8",
-    "eslint-config-next": "14.2.5",
+    "eslint-config-next": "^14.2.5",
     "eslint-plugin-jest-dom": "^5.4.0",
     "eslint-plugin-testing-library": "^6.3.0",
     "jest": "^29.7.0",

--- a/src/app/components/EventModule/EventModule.tsx
+++ b/src/app/components/EventModule/EventModule.tsx
@@ -1,0 +1,16 @@
+import { ParsedEvent } from "@/app/contentful/contentfulServices.types";
+import { Ticket } from "../Ticket/Ticket";
+
+export const EventModule = (event: ParsedEvent) => {
+  return (
+    <div className="h-auto bg-black">
+      <h1 className="text-3xl font-bold text-gold">{event.title}</h1>
+      <p>When: </p>
+      <p>
+        {event.tickets.map((ticket) => (
+          <Ticket key={ticket.title} ticket={ticket} />
+        ))}
+      </p>
+    </div>
+  );
+};

--- a/src/app/components/EventTeaserCard/EventTeaserCard.tsx
+++ b/src/app/components/EventTeaserCard/EventTeaserCard.tsx
@@ -1,0 +1,15 @@
+import { ParsedEvent } from "@/app/contentful/contentfulServices.types";
+import Link from "next/link";
+
+export const EventTeaserCard = ({ event }: { event: ParsedEvent }) => {
+  return (
+    <div className="h-80 w-80 bg-black opacity-90 p-4 text-white">
+      <h2 className="text-white font-bold text-center text-3xl">
+        {event.title}
+      </h2>
+      <p className=": text-center pt-8">{event.shortDescription}</p>
+      <p>Date: {event.date.getDate()}</p>
+      <Link href={`/events/${event.title}`}>See Full Details</Link>
+    </div>
+  );
+};

--- a/src/app/components/RichText/RichText.tsx
+++ b/src/app/components/RichText/RichText.tsx
@@ -1,0 +1,7 @@
+"use client";
+
+export const RichText = (data: any) => {
+  console.log(data);
+  console.log(typeof data.data);
+  return <div>Potato</div>;
+};

--- a/src/app/components/Ticket/Ticket.tsx
+++ b/src/app/components/Ticket/Ticket.tsx
@@ -1,0 +1,9 @@
+import { ParsedTicket } from "@/app/contentful/contentfulServices.types";
+
+export const Ticket = ({ ticket }: { ticket: ParsedTicket }) => {
+  return (
+    <div>
+      <h3>{ticket.title}</h3>
+    </div>
+  );
+};

--- a/src/app/contentful/contentfulService.ts
+++ b/src/app/contentful/contentfulService.ts
@@ -1,4 +1,4 @@
-import { PhotoGalleryResponse } from "./contentfulServices.types"
+import { ParsedEvent, PhotoGalleryResponse } from "./contentfulServices.types"
 import { eventsQuery } from "./graphQL/queries/events"
 import { photoAlbumQuery } from "./graphQL/queries/photoAlbum"
 import { parseEvents } from "./parsers/parseEvents"
@@ -30,7 +30,7 @@ export const contentfulService = () => {
         }
     }
 
-    const getEvents = async () => {
+    const getEvents = async (): Promise<ParsedEvent[]> => {
         const requestBody = JSON.stringify({query: eventsQuery})
 
         if (contentfulEndpoint) {

--- a/src/app/contentful/contentfulServices.types.ts
+++ b/src/app/contentful/contentfulServices.types.ts
@@ -7,7 +7,7 @@ export type PictureItem = {
     url: string;
 }
 
-export type Parsedticket = {
+export type ParsedTicket = {
     time: Date
     ticketsAvailble: string
     title: string 
@@ -30,14 +30,14 @@ export type PhotoGalleryResponse = {
     };
 };
 
-export type ParsedEvents = {
+export type ParsedEvent = {
     title: string
     date: Date
     price: number
     menu: EntryFieldTypes.RichText
     shortDescription: string
     longDescription: EntryFieldTypes.RichText
-    tickets: Parsedticket[]
+    tickets: ParsedTicket[]
 }
 
 export type ContentfulEventResponse= {

--- a/src/app/contentful/parsers/parseEvents.ts
+++ b/src/app/contentful/parsers/parseEvents.ts
@@ -1,6 +1,6 @@
-import { ContentfulEventResponse, ParsedEvents, Parsedticket, UnparsedTickets } from "../contentfulServices.types"
+import { ContentfulEventResponse, ParsedEvent, ParsedTicket, UnparsedTickets } from "../contentfulServices.types"
 
-export const parseEvents = (eventData: ContentfulEventResponse): ParsedEvents[] => {
+export const parseEvents = (eventData: ContentfulEventResponse): ParsedEvent[] => {
     return eventData.items.map( event => (
         {
             title: event.title,
@@ -14,7 +14,7 @@ export const parseEvents = (eventData: ContentfulEventResponse): ParsedEvents[] 
     ))
 }
 
-const parseTickets = (tickets: UnparsedTickets): Parsedticket[]  => {
+const parseTickets = (tickets: UnparsedTickets): ParsedTicket[]  => {
     return tickets.items.map((ticket) => ( {
         ...ticket,
         time: new Date(ticket.ticketsAvailble),

--- a/src/app/events/[eventPage]/page.tsx
+++ b/src/app/events/[eventPage]/page.tsx
@@ -1,0 +1,32 @@
+import { EventModule } from "@/app/components/EventModule/EventModule";
+import { MainLayout } from "@/app/components/mainLayout/MainLayout";
+import { contentfulService } from "@/app/contentful/contentfulService";
+import { headers } from "next/headers";
+
+export default async function EventPage() {
+  // Get Events
+  const contentful = contentfulService();
+  const eventData = await contentful.getEvents();
+  /**
+   * Get Event Title based on URL to populate the page with the right event
+   */
+  const headerList = headers();
+  const pathName = headerList.get("x-pathname") || "potato";
+  const eventTitleInURL = decodeURIComponent(
+    pathName.substring(pathName.lastIndexOf("/") + 1)
+  );
+
+  const eventOnPage = eventData.filter(
+    (event) => event.title === eventTitleInURL
+  )[0].event;
+
+  return (
+    <MainLayout>
+      {eventOnPage ? (
+        <EventModule event={eventOnPage} />
+      ) : (
+        <div>sad, no event</div>
+      )}
+    </MainLayout>
+  );
+}

--- a/src/app/events/[eventPage]/page.tsx
+++ b/src/app/events/[eventPage]/page.tsx
@@ -11,14 +11,14 @@ export default async function EventPage() {
    * Get Event Title based on URL to populate the page with the right event
    */
   const headerList = headers();
-  const pathName = headerList.get("x-pathname") || "potato";
+  const pathName = headerList.get("x-pathname") || "";
   const eventTitleInURL = decodeURIComponent(
     pathName.substring(pathName.lastIndexOf("/") + 1)
   );
 
   const eventOnPage = eventData.filter(
     (event) => event.title === eventTitleInURL
-  )[0].event;
+  )[0];
 
   return (
     <MainLayout>

--- a/src/app/events/page.tsx
+++ b/src/app/events/page.tsx
@@ -1,9 +1,22 @@
+import { EventTeaserCard } from "../components/EventTeaserCard/EventTeaserCard";
 import { MainLayout } from "../components/mainLayout/MainLayout";
+import { RichText } from "../components/RichText/RichText";
+import { contentfulService } from "../contentful/contentfulService";
 
-export default function Events() {
+export default async function Events() {
+  const contentful = contentfulService();
+  const eventData = await contentful.getEvents();
+  console.log(eventData, "eventData");
   return (
     <MainLayout>
-      <div>On Events Page</div>
+      <div className="p-8">
+        <h1 className="text-center text-4xl font-bold">Upcoming Events</h1>
+        <div>
+          {eventData.map((event) => (
+            <EventTeaserCard key={event.title} event={event} />
+          ))}
+        </div>
+      </div>
     </MainLayout>
   );
 }

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,0 +1,18 @@
+import { NextResponse } from 'next/server';
+
+export function middleware(request: Request) {
+
+const url = new URL(request.url);
+const origin = url.origin;
+const pathname = url.pathname;
+const requestHeaders = new Headers(request.headers);
+requestHeaders.set('x-url', request.url);
+requestHeaders.set('x-origin', origin);
+requestHeaders.set('x-pathname', pathname);
+
+return NextResponse.next({
+    request: {
+        headers: requestHeaders,
+    }
+});
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -3266,7 +3266,7 @@ escodegen@^2.0.0:
   optionalDependencies:
     source-map "~0.6.1"
 
-eslint-config-next@14.2.5:
+eslint-config-next@^14.2.5:
   version "14.2.5"
   resolved "https://registry.npmjs.org/eslint-config-next/-/eslint-config-next-14.2.5.tgz"
   integrity sha512-zogs9zlOiZ7ka+wgUnmcM0KBEDjo4Jis7kxN1jvC0N4wynQ2MIx/KBkg4mVF63J5EK4W0QMCn7xO3vNisjaAoA==


### PR DESCRIPTION
-Filter based on url
-Create shell subcomponents to be filled in
-connect shell subcomponents

To access the pathname on the url, a middleware file had to be added. This allowed for `headerList.get("x-pathname) to be called to grab the pathname, which after string manipulation could then be used to filter down the list of events.


**Potential future improvements:**

Create a second query to contentful that fetches an individual event instead of all the events and manually

Should I display a blank page if there is no event that matches a filter, or redirect. (Would need to figure out how to to do that from server component.