### PR TITLE
give fallback empty array return for bad call to contentful

### DIFF
--- a/src/app/contentful/contentfulService.ts
+++ b/src/app/contentful/contentfulService.ts
@@ -45,9 +45,14 @@ export const contentfulService = () => {
 
             
           const response = await fetch(contentfulEndpoint, fetchOptions)
-            const decodedResponse: {data: any} = await response.json()
-            
-            return await parseEvents(decodedResponse.data.eventTypeCollection)        }
+            const decodedResponse: {data: any} = await response.json()           
+            if (decodedResponse?.data?.eventTypeCollection) {
+                return await parseEvents(decodedResponse.data.eventTypeCollection)    
+            }
+            else {
+                return parseEvents(null)
+            }
+                    }
         else {
             return []
         }

--- a/src/app/contentful/parsers/parseEvents.ts
+++ b/src/app/contentful/parsers/parseEvents.ts
@@ -1,6 +1,10 @@
 import { ContentfulEventResponse, ParsedEvent, ParsedTicket, UnparsedTickets } from "../contentfulServices.types"
 
-export const parseEvents = (eventData: ContentfulEventResponse): ParsedEvent[] => {
+export const parseEvents = (eventData: ContentfulEventResponse | null): ParsedEvent[] => {
+    if (eventData === null) {
+        return []
+    }
+    
     return eventData.items.map( event => (
         {
             title: event.title,


### PR DESCRIPTION
Vercel was failing because of this error.
`TypeError: Cannot read properties of undefined (reading 'eventTypeCollection')
    at Object.getEvents (/vercel/path0/.next/server/app/events/page.js:34:987)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async o (/vercel/path0/.next/server/app/events/page.js:34:1548) {
  digest: '1794409580'`
  
 