### PR TITLE
Create route to add event to database

### DIFF
--- a/__test__/helpers/sortEventsByTime/sortEventsByTime.fixture.ts
+++ b/__test__/helpers/sortEventsByTime/sortEventsByTime.fixture.ts
@@ -4,6 +4,7 @@ import { BLOCKS } from "@contentful/rich-text-types";
 export const eventsFixture: ParsedEvent[] = [
     {
       title: 'In the past event',
+      contentfulId: 'abcdef',
       date: new Date(Date.now() - (1000 * 3600 * 24 * 5)), // 5 Days in the past
       price: 58,
       menu: { data: {}, content: [], nodeType: BLOCKS.DOCUMENT },
@@ -13,6 +14,7 @@ export const eventsFixture: ParsedEvent[] = [
     },
     {
       title: 'Way in the future event',
+      contentfulId: 'hijklmnop',
       date: new Date(Date.now() + (1000 * 3600 * 24 * 35)), // 35 Days in the future
       price: 58,
       menu: { data: {}, content: [], nodeType: BLOCKS.DOCUMENT },
@@ -22,6 +24,7 @@ export const eventsFixture: ParsedEvent[] = [
     },
     {
       title: 'Next Event',
+      contentfulId: 'qrstuvwxyz',
       date: new Date(Date.now() + (1000 * 3600 * 24 * 5)), // 5 days in the future
       price: 58,
       menu: { data: {}, content: [], nodeType: BLOCKS.DOCUMENT },

--- a/__test__/helpers/sortEventsByTime/sortEventsByTime.fixture.ts
+++ b/__test__/helpers/sortEventsByTime/sortEventsByTime.fixture.ts
@@ -1,0 +1,32 @@
+import { ParsedEvent } from "@/app/contentful/contentfulServices.types";
+import { BLOCKS } from "@contentful/rich-text-types";
+
+export const eventsFixture: ParsedEvent[] = [
+    {
+      title: 'In the past event',
+      date: new Date(Date.now() - (1000 * 3600 * 24 * 5)), // 5 Days in the past
+      price: 58,
+      menu: { data: {}, content: [], nodeType: BLOCKS.DOCUMENT },
+      shortDescription: 'It was so good, you completely missed out. You should feel bad.',
+      tickets: [ ],
+      longDescription: { data: {}, content: [], nodeType: BLOCKS.DOCUMENT }
+    },
+    {
+      title: 'Way in the future event',
+      date: new Date(Date.now() + (1000 * 3600 * 24 * 35)), // 35 Days in the future
+      price: 58,
+      menu: { data: {}, content: [], nodeType: BLOCKS.DOCUMENT },
+      shortDescription: "This event is way in the future, but it'll be dope",
+      tickets: [ ],
+      longDescription: { data: {}, content: [], nodeType: BLOCKS.DOCUMENT }
+    },
+    {
+      title: 'Next Event',
+      date: new Date(Date.now() + (1000 * 3600 * 24 * 5)), // 5 days in the future
+      price: 58,
+      menu: { data: {}, content: [], nodeType: BLOCKS.DOCUMENT },
+      shortDescription: 'I am having a pop-up on a certain date that is happening in the near future! I am so excited, blah blah blah blah blah',
+      tickets: [ ],
+      longDescription: { data: {}, content: [], nodeType: BLOCKS.DOCUMENT }
+    }
+  ]

--- a/__test__/helpers/sortEventsByTime/sortEventsByTime.test.ts
+++ b/__test__/helpers/sortEventsByTime/sortEventsByTime.test.ts
@@ -1,0 +1,22 @@
+import { sortEventsByTime } from "@/app/helpers/sortEventsByTime"
+import { eventsFixture } from "./sortEventsByTime.fixture"
+
+describe('SortEventsByTime', () => {
+    it('Returns an object with 2 empty arrays if there are no events', ()=> {
+        const sortedEvents = sortEventsByTime([])
+        
+        expect(sortedEvents.pastEvents).toHaveLength(0)
+        expect(sortedEvents.upcomingEvents).toHaveLength(0)
+    })
+
+    it('Sorts events from soonest to furthest out', () => {
+        const {pastEvents, upcomingEvents} = sortEventsByTime(eventsFixture)
+
+        expect(pastEvents).toHaveLength(1)
+        expect(pastEvents[0].title).toEqual('In the past event')
+
+        expect(upcomingEvents).toHaveLength(2)
+        expect(upcomingEvents[0].title).toEqual('Next Event')
+        expect(upcomingEvents[1].title).toEqual('Way in the future event')
+    })
+})

--- a/src/app/api/addEvent/route.ts
+++ b/src/app/api/addEvent/route.ts
@@ -1,9 +1,25 @@
+import { contentfulService } from "@/app/contentful/contentfulService";
+import { sortEventsByTime } from "@/app/helpers/sortEventsByTime";
 import { db } from "@/db";
-import { eventsTable } from "@/db/schema";
-import { eq } from "drizzle-orm";
+import { NextResponse } from "next/server";
+import { createEventWithTickets } from "../queries/insert";
 
 
 export async function POST(request: Request) {
-    const contentfulId = 'abcd'
-    const event = db.select().from(eventsTable).where(eq(eventsTable.cotentfulId, contentfulId) )
+    const contentful = contentfulService();
+    const eventData = await contentful.getEvents();
+    const {upcomingEvents} = sortEventsByTime(eventData)
+    
+    const eventsInDatabase = await db.query.eventsTable.findMany()
+
+    const eventsNotInDatabase = upcomingEvents.filter(event => {
+        return !eventsInDatabase.find(savedEvent => savedEvent.contentfulId === event.contentfulId)
+    })
+
+    if (eventsNotInDatabase.length > 0) {
+    await createEventWithTickets(eventsNotInDatabase)
+    }
+    
+    
+    return NextResponse.json({status: 200})
 }

--- a/src/app/api/queries/insert.ts
+++ b/src/app/api/queries/insert.ts
@@ -1,7 +1,53 @@
+import { ParsedEvent } from "@/app/contentful/contentfulServices.types";
 import { db } from "@/db";
-import { customersTable, InsertCustomer } from "@/db/schema";
+import { customersTable, eventsTable, InsertCustomer, InsertEvent, InsertTicket, ticketsTable } from "@/db/schema";
 
 
 export async function createCustomer(data: InsertCustomer) {
-    await db.insert(customersTable).values(data)
+    return await db.insert(customersTable).values(data)
+}
+
+export async function createEvent(data: InsertEvent[]) {
+   return await db.insert(eventsTable).values(data).returning({id: eventsTable.id})
+}
+
+export async function createTicket(data: InsertTicket[]) {
+   return await db.insert(ticketsTable).values(data)
+}
+
+export async function createEventWithTickets(parsedEvents: ParsedEvent[]) {
+    
+    /**
+     * Reshape and add Event to database
+     */
+    const eventsToInsert: InsertEvent[] = parsedEvents.map(currentEvent => {
+        return {
+            title: currentEvent.title,
+            contentfulId: currentEvent.contentfulId,
+            date: currentEvent.date
+        }
+    })
+
+    const insertedEvents = await createEvent(eventsToInsert)
+
+    /** Reshape Tickets for insertion with a key to the event already added */
+    const ticketsToInsert: InsertTicket[] = []
+    insertedEvents.forEach((insertedEvent, index) => {
+        const parsedEvent = parsedEvents[index];
+        parsedEvent.tickets.forEach((ticket) => {
+            
+            ticketsToInsert.push({
+                contentfulId: ticket.contentfulId,
+                event: insertedEvent.id,  // Associate this ticket with the correct event
+                totalAvailable: ticket.ticketsAvailable,
+                totalSold: 0,  // Assuming tickets start with 0 sold
+                time: ticket.time
+            });
+        });
+    });
+
+    /**
+     * Put tickets into database
+     */
+    createTicket(ticketsToInsert)
 }

--- a/src/app/contentful/contentfulServices.types.ts
+++ b/src/app/contentful/contentfulServices.types.ts
@@ -8,6 +8,7 @@ export type PictureItem = {
 }
 
 export type ParsedTicket = {
+    contentfulId: string
     time: Date
     ticketsAvailable: number
     title: string 
@@ -15,6 +16,7 @@ export type ParsedTicket = {
 
 export type UnparsedTickets = {
     items: {
+        _id: string
         ticketTime: string
         ticketsAvailable: string
         title: string
@@ -31,6 +33,7 @@ export type PhotoGalleryResponse = {
 };
 
 export type ParsedEvent = {
+    contentfulId: string
     title: string
     date: Date
     price: number
@@ -42,6 +45,7 @@ export type ParsedEvent = {
 
 export type ContentfulEventResponse= {
     items: {
+    _id: string
     title: string
     shortDescription: string
     price: number

--- a/src/app/contentful/graphQL/queries/events.ts
+++ b/src/app/contentful/graphQL/queries/events.ts
@@ -1,6 +1,7 @@
 export const eventsQuery = `query fetch{
     eventTypeCollection(limit:5){
     items{
+        _id
         title
         date
         shortDescription
@@ -13,6 +14,7 @@ export const eventsQuery = `query fetch{
         }
         ticketsCollection(limit:10){
             items{
+                _id
                 title
                 ticketTime
                 ticketsAvailable

--- a/src/app/contentful/parsers/parseEvents.ts
+++ b/src/app/contentful/parsers/parseEvents.ts
@@ -7,6 +7,7 @@ export const parseEvents = (eventData: ContentfulEventResponse | null): ParsedEv
     
     return eventData.items.map( event => (
         {
+            contentfulId: event._id,
             title: event.title,
             date: new Date(event.date),
             price: event.price,
@@ -21,6 +22,7 @@ export const parseEvents = (eventData: ContentfulEventResponse | null): ParsedEv
 const parseTickets = (tickets: UnparsedTickets): ParsedTicket[]  => {
     return tickets.items.map((ticket) => ( {
         ...ticket,
+        contentfulId: ticket._id,
         ticketsAvailable: Number(ticket.ticketsAvailable),
         time: new Date(ticket.ticketTime),
     }))

--- a/src/app/events/page.tsx
+++ b/src/app/events/page.tsx
@@ -1,3 +1,4 @@
+import { eventsFixture } from "../../../__test__/helpers/sortEventsByTime/sortEventsByTime.fixture";
 import { EventTeaserCard } from "../components/EventTeaserCard/EventTeaserCard";
 import { MainLayout } from "../components/mainLayout/MainLayout";
 import { contentfulService } from "../contentful/contentfulService";
@@ -7,7 +8,6 @@ import { sortEventsByTime } from "../helpers/sortEventsByTime";
 export default async function Events() {
   const contentful = contentfulService();
   const eventData = await contentful.getEvents();
-
   const { upcomingEvents, pastEvents } = sortEventsByTime(eventData);
 
   return (

--- a/src/app/events/page.tsx
+++ b/src/app/events/page.tsx
@@ -2,30 +2,13 @@ import { EventTeaserCard } from "../components/EventTeaserCard/EventTeaserCard";
 import { MainLayout } from "../components/mainLayout/MainLayout";
 import { contentfulService } from "../contentful/contentfulService";
 import { ParsedEvent } from "../contentful/contentfulServices.types";
+import { sortEventsByTime } from "../helpers/sortEventsByTime";
 
 export default async function Events() {
-  const upcomingEvents: ParsedEvent[] = [];
-  const pastEvents: ParsedEvent[] = [];
   const contentful = contentfulService();
   const eventData = await contentful.getEvents();
 
-  if (eventData.length) {
-    eventData.forEach((event) => {
-      if (event?.date && event?.date < new Date()) {
-        pastEvents.push(event);
-      } else {
-        upcomingEvents.push(event);
-      }
-    });
-
-    upcomingEvents.sort((a, b) => {
-      if (a?.date && b?.date) {
-        return a?.date?.valueOf() - b?.date?.valueOf();
-      } else {
-        return a.price - b.price;
-      }
-    });
-  }
+  const { upcomingEvents, pastEvents } = sortEventsByTime(eventData);
 
   return (
     <MainLayout>

--- a/src/app/helpers/sortEventsByTime.ts
+++ b/src/app/helpers/sortEventsByTime.ts
@@ -1,0 +1,30 @@
+import { ParsedEvent } from "../contentful/contentfulServices.types";
+
+
+
+export const sortEventsByTime = (parsedEvents: ParsedEvent[]) => {
+    const upcomingEvents: ParsedEvent[] = []
+    const pastEvents: ParsedEvent[] = []
+    
+    if (parsedEvents.length === 0) {
+        return {upcomingEvents, pastEvents}
+    }
+
+    parsedEvents.forEach((event) => {
+        if (event?.date && event?.date < new Date()) {
+          pastEvents.push(event);
+        } else {
+          upcomingEvents.push(event);
+        }
+      });
+  
+      upcomingEvents.sort((a, b) => {
+        if (a?.date && b?.date) {
+          return a?.date?.valueOf() - b?.date?.valueOf();
+        } else {
+          return a.price - b.price;
+        }
+      });
+
+      return {upcomingEvents, pastEvents}
+}

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -22,8 +22,8 @@ export const ticketsTable = sqliteTable('tickets', {
 export const eventsTable = sqliteTable('events', {
     id: integer('id').primaryKey(),
     title: text('title').notNull(),
-    cotentfulId: text('contentfulId').notNull(),
-    time: integer('time', {mode: 'timestamp'})
+    date: integer('time', {mode: 'timestamp'}),
+    contentfulId: text('contentfulId').notNull(),
 })
 
 export const purchasesTable = sqliteTable('purchases', {


### PR DESCRIPTION
Creates endpoint `/api/addEvent`

Queries contentful for all events, grabs events from database, then conditionally adds all events not in the database and associated tickets to the database. 

Logic to take an array of events and split it into two separate arrays of upcoming / past events has been moved from a page component to a helper component, and a unit test was added to support. 