### PR TITLE
update events from contentful

### DIFF
--- a/src/app/api/addEvent/route.ts
+++ b/src/app/api/addEvent/route.ts
@@ -3,23 +3,33 @@ import { sortEventsByTime } from "@/app/helpers/sortEventsByTime";
 import { db } from "@/db";
 import { NextResponse } from "next/server";
 import { createEventWithTickets } from "../queries/insert";
-
+import { updateExistingEvents } from "../queries/update";
 
 export async function POST(request: Request) {
     const contentful = contentfulService();
     const eventData = await contentful.getEvents();
-    const {upcomingEvents} = sortEventsByTime(eventData)
+    const { upcomingEvents } = sortEventsByTime(eventData);
     
-    const eventsInDatabase = await db.query.eventsTable.findMany()
+    const eventsInDatabase = await db.query.eventsTable.findMany();
 
     const eventsNotInDatabase = upcomingEvents.filter(event => {
-        return !eventsInDatabase.find(savedEvent => savedEvent.contentfulId === event.contentfulEventId)
-    })
+        return !eventsInDatabase.find(savedEvent => savedEvent.contentfulId === event.contentfulEventId);
+    });
+
+    const eventsToUpdate = upcomingEvents.filter(event => {
+        return eventsInDatabase.find(savedEvent => savedEvent.contentfulId === event.contentfulEventId);
+    });
 
     if (eventsNotInDatabase.length > 0) {
-    await createEventWithTickets(eventsNotInDatabase)
+        await createEventWithTickets(eventsNotInDatabase);
+    }
+
+    if (eventsToUpdate.length > 0) {
+        await updateExistingEvents(eventsToUpdate);
     }
     
-    
-    return NextResponse.json({status: 200})
+    return NextResponse.json({ status: 200 });
 }
+
+
+

--- a/src/app/api/api.types.ts
+++ b/src/app/api/api.types.ts
@@ -19,3 +19,16 @@ export type DatabaseTickets = {
         totalSold: number
     }
 }
+
+export type UpdatedTicketFields = {
+    totalAvailable?: number;
+    id?: number 
+    time?: Date 
+    event?: number 
+    price?: number 
+}
+
+export type UpdatedEventFields = {
+title?: string
+date?: Date 
+}

--- a/src/app/api/queries/update.ts
+++ b/src/app/api/queries/update.ts
@@ -1,0 +1,68 @@
+import { ParsedEvent } from "@/app/contentful/contentfulServices.types";
+import { db } from "@/db";
+import { eventsTable, ticketsTable } from "@/db/schema";
+import { sql } from 'drizzle-orm';
+import { UpdatedEventFields, UpdatedTicketFields } from "../api.types";
+
+export async function updateExistingEvents(events: ParsedEvent[]) {
+    for (const event of events) {
+        const existingEvent = await db.query.eventsTable.findFirst({
+            where: sql`${eventsTable.contentfulId} = ${event.contentfulEventId}`
+        });
+
+        if (existingEvent) {
+            const updatedFields: UpdatedEventFields = {};
+
+            if (event?.title && existingEvent.title !== event.title) {
+                updatedFields['title'] = event.title;
+            }
+            if (event?.date && existingEvent.date !== event.date) {
+                updatedFields['date'] = event.date;
+            }
+            // Add other fields as necessary
+
+            if (Object.keys(updatedFields).length > 0) {
+                await db.update(eventsTable)
+                    .set(updatedFields)
+                    .where(sql`${eventsTable.contentfulId} = ${event.contentfulEventId}`);
+            }
+
+            // Update tickets
+            for (const ticket of event.tickets) {
+                const existingTicket = await db.query.ticketsTable.findFirst({
+                    where: sql`${ticketsTable.contentfulId} = ${ticket.contentfulTicketId}`
+                });
+
+                if (existingTicket) {
+                    const updatedTicketFields: UpdatedTicketFields = {};
+
+                    if (ticket?.time && existingTicket.time !== ticket.time) {
+                        updatedTicketFields['time'] = new Date(ticket.time);
+                    }
+                    if (ticket?.ticketsAvailable && existingTicket.totalAvailable !== ticket.ticketsAvailable) {
+                        updatedTicketFields['totalAvailable'] = ticket.ticketsAvailable;
+                    }
+                    if (ticket?.price !== undefined && existingTicket.price !== ticket.price) {
+                        updatedTicketFields['price'] = ticket.price;
+                    }
+
+                    if (Object.keys(updatedTicketFields).length > 0) {
+                        await db.update(ticketsTable)
+                            .set(updatedTicketFields)
+                            .where(sql`${ticketsTable.contentfulId} = ${ticket.contentfulTicketId}`);
+                    }
+                } else {
+                    // Insert new ticket if it doesn't exist
+                    await db.insert(ticketsTable).values({
+                        contentfulId: ticket.contentfulTicketId,
+                        event: existingEvent.id,  // Associate this ticket with the correct event
+                        totalAvailable: ticket.ticketsAvailable,
+                        totalSold: 0,  // Assuming tickets start with 0 sold
+                        time: ticket.time
+                    });
+                }
+            }
+        }
+    }
+}
+

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -14,6 +14,7 @@ export const ticketsTable = sqliteTable('tickets', {
     id: integer('id').primaryKey(),
     contentfulId: text('contentfulId').notNull(),
     event: integer('event_id').references(() => eventsTable.id),
+    price: integer('price'),
     totalAvailable: integer('totalAvailable').notNull(),
     totalSold: integer('totalSold').notNull(),
     time: integer('time', {mode: 'timestamp'})


### PR DESCRIPTION
This updates the `/api/addEvent` route to look at existing upcoming events, and if any of the fields that is stored in the database is different to then update that field. 

There is for sure optimization that can be done with the query to cut down on the number of database calls that are made. However, this gets the job done for now, and in testing, the fields are accurately updated.